### PR TITLE
Feature/#009

### DIFF
--- a/Django_App/users/views.py
+++ b/Django_App/users/views.py
@@ -4,6 +4,8 @@ from django.views.generic.base import TemplateView
 from users.forms import RegistForm, UserLoginForm
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.views import LoginView, LogoutView
+from django.urls import reverse_lazy
+from django.contrib.auth import authenticate, login
 
 # TODO:homeはactivityアプリを作成した後に削除
 # Home画面
@@ -15,6 +17,15 @@ class HomeView(LoginRequiredMixin, TemplateView):
 class RegistUserView(CreateView):
     template_name = 'regist.html'
     form_class = RegistForm
+    success_url = reverse_lazy('users:home')
+
+    def form_valid(self, form):
+        response = super().form_valid(form)
+        email = form.cleaned_data.get('email')
+        password = form.cleaned_data.get('password')
+        user = authenticate(email=email, password=password)
+        login(self.request, user)
+        return response
 
 # login用
 class UserLoginView(LoginView):

--- a/Django_App/utils/validations.py
+++ b/Django_App/utils/validations.py
@@ -4,7 +4,7 @@ import re
 # 自作バリデーション
 class CustomPasswordValidator():
   # バリデーションメッセージ
-  msg = 'パスワードには、0-9, a-zを含めてください'
+  msg = 'パスワードには、0-9, A-Z, a-zを含めてください'
 
   def __init__(self):
     pass
@@ -13,6 +13,7 @@ class CustomPasswordValidator():
   def validate(self,password,user=None):
     if all(
       (re.search('[0-9]', password), 
+      re.search('[A-Z]', password), 
       re.search('[a-z]', password))):
       # 記号を追加する場合は、「re.search('[#$%&]', password)」を追加する
       return


### PR DESCRIPTION
## 目的
パスワード登録とユーザー登録の挙動修正

## 実装の概要/やったこと
パスワード登録にA-Zを含めないと登録できないように変更
ユーザー登録時にhome画面へ遷移するように変更

## 保留/やらないこと
バリデーションエラーの内容変更は保留

## できるようになること（ユーザ目線）
なし

## できなくなること（ユーザ目線）
パスワードがA-Zを含まない状態で登録できない

## 動作確認
パスワード作成のをする際、A-Zを含まない場合は登録できないか、エラーは表示されるか
ユーザー登録後はhome画面へ遷移されるのか

## その他

* バリデーションエラーの部分は未解決
* close 関連するissue番号
* @dan-k4 
