### PR TITLE
カテゴリー削除機能(論理削除)

### DIFF
--- a/Django_App/categories/admin.py
+++ b/Django_App/categories/admin.py
@@ -1,5 +1,8 @@
 from django.contrib import admin
 from .models import Category, ActivityCategory
 
-admin.site.register(Category)
+class CategoryAdmin(admin.ModelAdmin):
+    list_display = ('id', 'name', 'user', 'goal', 'color_code', 'created_at', 'updated_at', 'is_deleted')
+
+admin.site.register(Category, CategoryAdmin)
 admin.site.register(ActivityCategory)

--- a/Django_App/categories/urls.py
+++ b/Django_App/categories/urls.py
@@ -10,4 +10,5 @@ urlpatterns = [
     path('restore/<int:pk>/', views.category_restore, name='category_restore'),
     path('<int:pk>/edit/', views.CategoryEditView.as_view(), name='category_edit'),
     path('check_duplicate_edit/', views.check_duplicate_edit, name='check_duplicate_edit'),
+    path('<int:pk>/delete/', views.CategoryDeleteView.as_view(), name='category_delete')
 ]

--- a/Django_App/categories/views.py
+++ b/Django_App/categories/views.py
@@ -3,6 +3,7 @@ from django.views import generic
 from django.urls import reverse_lazy
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import JsonResponse, HttpResponseRedirect
+from django.shortcuts import get_object_or_404, redirect
 import json
 from .models import Category
 from .forms import CategoryForm
@@ -84,8 +85,10 @@ def check_duplicate_edit(request):
     else:
         return JsonResponse({"error": "Invalid request method"})
 
-
-
-# TODO: カテゴリーの削除機能
-    #* カテゴリー毎のhome画面で削除モーダルを表示し削除
-    #* カテゴリー削除はis_deletedをtureに変更
+# カテゴリー削除(論理削除)
+class CategoryDeleteView(LoginRequiredMixin, generic.View):
+    def post(self, request, *args, **kwargs):
+        category = get_object_or_404(Category, id=kwargs['pk'], user=request.user)
+        category.is_deleted = True
+        category.save()
+        return HttpResponseRedirect(reverse_lazy('activity:home'))

--- a/Django_App/categories/views.py
+++ b/Django_App/categories/views.py
@@ -3,7 +3,7 @@ from django.views import generic
 from django.urls import reverse_lazy
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import JsonResponse, HttpResponseRedirect
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import get_object_or_404
 import json
 from .models import Category
 from .forms import CategoryForm


### PR DESCRIPTION
## 目的
- カテゴリーの論理削除の作成

## 実装の概要/やったこと
- カテゴリーの論理削除

## 保留/やらないこと
- なし

## できるようになること（ユーザ目線）
- カテゴリーの論理削除

## できなくなること（ユーザ目線）
- なし

## 動作確認
- ブラウザで確認

## その他
- 現状urlでしか確認できなかったので、メソッドを確認時のみget変更してis_deletedがtureになるか検証
* close #33 
* @mappii130 
